### PR TITLE
Add missing cargo-features line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "aedat"
 version = "1.2.2"


### PR DESCRIPTION
I get this error when trying to package `aedat`:
```
`cargo metadata` exited with an error: error: failed to parse manifest at `/home/conda/feedstock_root/build_artifacts/aedat_1635312531807/work/Cargo.toml`

Caused by:
  feature `edition2021` is required

  The package requires the Cargo feature called `edition2021`, but that feature is not stabilized in this version of Cargo (1.56.0-nightly (b51439fd8 2021-08-09)).
  Consider adding `cargo-features = ["edition2021"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2021 for more information about the status of this feature.
```

This should fix it.